### PR TITLE
Fix // Build with Rust 1.80+ and update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,9 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "imagesize"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "indexmap"
@@ -1981,6 +1981,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,9 +2153,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "open"
-version = "4.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a083c0c7e5e4a8ec4176346cf61f67ac674e8bfb059d9226e1c54a96b377c12"
+checksum = "61a877bf6abd716642a53ef1b89fb498923a4afca5c754f9050b4d081c05c4b3"
 dependencies = [
  "is-wsl",
  "libc",
@@ -2806,13 +2812,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.31"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
  "libc",
+ "num-conv",
  "num_threads",
  "powerfmt",
  "serde",
@@ -2828,10 +2835,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -3498,6 +3506,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,16 @@ repository = "https://github.com/Satellile/yara"
 
 [dependencies]
 serde_json = "1.0.113"
-isahc = {version = "1.7.2", features = ["json", "cookies", "text-decoding"] }
+isahc = { version = "1.7.2", features = ["json", "cookies", "text-decoding"] }
 serde = { version = "1.0.164", features = ["derive"] }
 notan = { version = "0.11.0", features = ["extra"] }
-imagesize = "0.12.0"
+imagesize = "0.13.0"
 clipboard = "0.5.0"
 regex = "1.8.4"
-open = "4.1.0"
+open = "5.3.0"
 native-dialog = "0.7.0"
 blake3 = "1.5.0"
 crc32fast = "1.3.2"
 
-json5 = "0.4.1" # Some custom nodes have NaN values, which serde_json doesn't seem to handle as easily. I use this as a fallback
+time = ">=0.3.35" # necessary as of Rust 1.80
+json5 = "0.4.1"   # Some custom nodes have NaN values, which serde_json doesn't seem to handle as easily. I use this as a fallback

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use std::io::{Read, BufReader, Write};
 use std::path::{PathBuf, Path};
 use std::fs;
 use std::collections::HashMap;
-use std::process::Command;
 use std::{thread, time::{Duration, Instant}};
 
 use serde_json::{Value, Map};


### PR DESCRIPTION
Hi,

This PR fixes the build with rust 1.80+ caused by some breaking api change that impacts the time crate. While I was in the trenches, I also updated the other dependencies and fixed an unused warning.

Cheers